### PR TITLE
Don't rely on Ok or Err for logging Results

### DIFF
--- a/examples/result.rs
+++ b/examples/result.rs
@@ -1,0 +1,29 @@
+use std::fmt;
+
+use log_derive::logfn;
+use simplelog::{TermLogger, Config};
+use log::LevelFilter;
+
+struct DivisibleBy3Error(u32);
+
+impl fmt::Display for DivisibleBy3Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} is divisible by 3", self.0)
+    }
+}
+
+#[logfn(fmt = "not_divisible_by_3() -> {}", ok = "info", err = "error")]
+fn not_divisible_by_3(n: u32) -> Result<u32, DivisibleBy3Error> {
+    match n % 3 {
+        0 => Err(DivisibleBy3Error(n)),
+        _ => Ok(n)
+    }
+}
+
+
+fn main() {
+    TermLogger::init(LevelFilter::Trace, Config::default()).unwrap();
+    for x in 0..25 {
+        let _ = not_divisible_by_3(x);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,17 +214,9 @@ fn generate_function(closure: &ExprClosure, expressions: &FormattedAttributes, r
     let code = if result {
         quote!{
             fn temp() {
-                let result = (#closure)();
-                match result {
-                    Ok(result) => {
-                        #ok_expr;
-                        return Ok(result);
-                    }
-                    Err(err) => {
-                        #err_expr;
-                        return Err(err);
-                    }
-                }
+                (#closure)()
+                    .map(|result| { #ok_expr; result })
+                    .map_err(|err| { #err_expr; err })
             }
         }
     } else {


### PR DESCRIPTION
Instead use inherent methods on Result.
This will work with no_std or when Ok/Err have been redefined.

Fixes #4