### PR TITLE
Use darling for attribute parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["development-tools::debugging"]
 keywords = ["log", "macro", "derive", "logging", "function"]
 
 [dependencies]
+darling = "0.8.5"
+ident_case = "1.0.0"
 proc-macro2 = "0.4"
 #syn = { version = "0.15", features = ["full", "extra-traits"] } # -> For development
 syn = { version = "0.15", features = ["full"] }

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -2,7 +2,17 @@ use log_derive::logfn;
 use simplelog::{TermLogger, Config};
 use log::LevelFilter;
 
-#[logfn(INFO, fmt = "fibonacci() -> {}")]
+// #[logfn(INFO, fmt = "fibonacci() -> {:?}", err = "Error", ok = "Trace", Warn)]
+// fn fibonacci(n: u32) -> std::result::Result<u32, u32> {
+//     match n {
+//         0 => Ok(1),
+//         1 => Ok(1),
+//         3 => Err(3),
+//         _ => Ok(fibonacci(n - 1)? + fibonacci(n - 2)?),
+//     }
+// }
+
+#[logfn(INFO, fmt = "fibonacci() -> {}", ok = "Trace")]
 fn fibonacci(n: u32) -> u32 {
     match n {
         0 => 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,7 @@ struct FormattedAttributes {
 }
 
 impl FormattedAttributes {
-    // We allow the ptr_arg here as `AttributeArgs` is just `Vec<Attribute>`, but
-    // for clarity's sake we don't want to desugar that in the function signature.
-    #[allow(clippy::ptr_arg)]
-    pub fn parse_attributes(attr: &AttributeArgs) -> darling::Result<Self> {
+    pub fn parse_attributes(attr: &[NestedMeta]) -> darling::Result<Self> {
         Options::from_list(attr).map(|opts| get_ok_err_streams(&opts))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ struct FormattedAttributes {
 }
 
 impl FormattedAttributes {
-    pub fn parse_attributes(attr: AttributeArgs) -> darling::Result<Self> {
-        Options::from_list(&attr).map(get_ok_err_streams)
+    pub fn parse_attributes(attr: &AttributeArgs) -> darling::Result<Self> {
+        Options::from_list(attr).map(|opts| get_ok_err_streams(&opts))
     }
 }
 
@@ -153,7 +153,7 @@ impl FromMeta for Options {
     }
 }
 
-fn get_ok_err_streams(att: Options) -> FormattedAttributes {
+fn get_ok_err_streams(att: &Options) -> FormattedAttributes {
     let ok_log = att.ok_log();
     let err_log = att.err_log();
     let fmt = att.fmt().unwrap_or("LOG DERIVE: {:?}");
@@ -278,7 +278,7 @@ fn generate_function(closure: &ExprClosure, expressions: &FormattedAttributes, r
 #[proc_macro_attribute]
 pub fn logfn(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let attr = parse_macro_input!(attr as AttributeArgs);
-    let parsed_attributes = match FormattedAttributes::parse_attributes(attr) {
+    let parsed_attributes = match FormattedAttributes::parse_attributes(&attr) {
         Ok(val) => val,
         Err(err) => {
             return err.write_errors().into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@ struct FormattedAttributes {
 }
 
 impl FormattedAttributes {
+    // We allow the ptr_arg here as `AttributeArgs` is just `Vec<Attribute>`, but
+    // for clarity's sake we don't want to desugar that in the function signature.
+    #[allow(clippy::ptr_arg)]
     pub fn parse_attributes(attr: &AttributeArgs) -> darling::Result<Self> {
         Options::from_list(attr).map(|opts| get_ok_err_streams(&opts))
     }


### PR DESCRIPTION
This offloads attribute parsing to darling, providing good error messages and stricter input handling

Fixes #5 and helps with #4 

Full disclosure: I'm a bit biased here, since I wrote `darling` after getting frustrated with attribute parsing working on `derive-builder`. However, I do think it helps take the burden of attribute parsing off this crate, and I'm actively working on new ways to make `darling` produce great error messages without crates like `log-derive` having to do anything.