### PR TITLE
Treat types ending in "Result" as result types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl FromMeta for OutputOptions {
 /// from specific modules.
 pub(crate) fn is_result_type(ty: &TypePath) -> bool {
     if let Some(segment) = ty.path.segments.iter().last() {
-        segment.ident == "Result"
+        segment.ident.to_string().ends_with("Result")
     } else {
         false
     }
@@ -459,8 +459,15 @@ mod tests {
 
     use super::is_result_type;
 
+    enum CustomError {
+        Test,
+    }
+
+    type CustomResult<T> = Result<T, CustomError>;
+
     #[test]
     fn result_type() {
+        assert!(is_result_type(&parse_quote!(CustomResult<T, E>)));
         assert!(is_result_type(&parse_quote!(Result<T, E>)));
         assert!(is_result_type(&parse_quote!(std::result::Result<T, E>)));
         assert!(is_result_type(&parse_quote!(fmt::Result)));


### PR DESCRIPTION
It is quite common to define custom error enums and combine them with a Result type alias, e.g.:
```rust
enum CustomError {
    Test,
}

type CustomResult<T> = Result<T, CustomError>;
```
However, this isn't being caught by log-derive (a similar issue has been https://github.com/elichai/log-derive/pull/6).
This PR changes the `is_result_type` function to accept all types that *end* in Result, which seems to cover additional cases.

I'm not sure if this change has any negative implications, but it works nicely for my use-case. :smile: 
